### PR TITLE
Update runphasenet.py

### DIFF
--- a/Pick/PhaseNet/runphasenet.py
+++ b/Pick/PhaseNet/runphasenet.py
@@ -33,10 +33,10 @@ samplingrate = 0.01 #samplingrate of your data, default 100 hz
 f = open(output1,'w')
 g = open(output2,'w')
 data = pd.read_csv(pickfile, parse_dates=["begin_time", "phase_time"])
-data = data[data["phase_score"] >= prob_threshold]
+data = data[data["phase_score"] >= prob_threshold].reset_index(drop=True)
 
 data[["year", "mon", "day"]] = data["begin_time"].apply(lambda x: pd.Series([x.year, x.month, x.day]))
-data["ss"] = data["begin_time"].apply(lambda x: (x - datetime.fromisoformat(f"{x.year}-{x.month}-{x.day}")).total_seconds())
+data["ss"] = data["begin_time"].apply(lambda x: (x - datetime.fromisoformat(f"{x.year:04d}-{x.month:02d}-{x.day:02d}")).total_seconds())
 data[["net", "name", "channel"]] = data["station_id"].apply(lambda x: pd.Series(x.split(".")))
 data["dum"] = pd.Series(np.ones(len(data)))
 data["phase_amp"] = data["phase_amp"] * 2080 * 20

--- a/Pick/PhaseNet/runphasenet.py
+++ b/Pick/PhaseNet/runphasenet.py
@@ -35,7 +35,7 @@ g = open(output2,'w')
 data = pd.read_csv(pickfile, parse_dates=["begin_time", "phase_time"])
 data = data[data["phase_score"] >= prob_threshold].reset_index(drop=True)
 
-data[["year", "mon", "day"]] = data["begin_time"].apply(lambda x: pd.Series([x.year, x.month, x.day]))
+data[["year", "mon", "day"]] = data["begin_time"].apply(lambda x: pd.Series([f"{x.year:04d}", f"{x.month:02d}", f"{x.day:02d}"]))
 data["ss"] = data["begin_time"].apply(lambda x: (x - datetime.fromisoformat(f"{x.year:04d}-{x.month:02d}-{x.day:02d}")).total_seconds())
 data[["net", "name", "channel"]] = data["station_id"].apply(lambda x: pd.Series(x.split(".")))
 data["dum"] = pd.Series(np.ones(len(data)))


### PR DESCRIPTION
Address comments:

1. Line 39 of runphasenet.py
It reported an error when handling single digit day of month and month of year (in my case, Jan. 3, for example). I therefore changed to 
 
data["ss"] = data["begin_time"].apply(lambda x: (x - datetime.fromisoformat(datetime(x.year,x.month,x.day).strftime("%Y-%m-%d"))).total_seconds())
 
2. Line 41 of runphasenet.py
I noticed this error because of the inconsistent indices between "data" after removing picks with low probability and the panda series "dum", which results in a null column in the final picks' files. I changed to
 
dum = pd.Series(np.ones(len(data))); dum.index = data.index; data["dum"] = dum
 